### PR TITLE
User and public nonuser cards display on Community tab

### DIFF
--- a/components/forms/addCategoryForm.js
+++ b/components/forms/addCategoryForm.js
@@ -5,12 +5,12 @@ import { selectCommunityCategory } from './selectCategory';
 const addCategoryForm = (uid) => {
   clearDom();
   const formHTML = `
-    <form id="create-category" class="add-category">
+    <form id="create-category" class="add-form">
       <div class="mb-3">
         <label for="new-category" class="form-label">Enter Category Name</label>
         <input type="text" class="form-control" id="new-category" aria-describedby="categoryHelp" required>
       </div>
-      <button type="submit" class="btn btn-success">Submit</button>
+      <button type="submit" class="btn btn-success">Create Category</button>
     </form>`;
   renderToDom('#form-container', formHTML);
   selectCommunityCategory(uid);

--- a/components/forms/addTermForm.js
+++ b/components/forms/addTermForm.js
@@ -5,7 +5,7 @@ import { selectCategory } from './selectCategory';
 const addTermForm = (uid, term = {}) => {
   clearDom();
   const formHTML = `
-    <form id="${term.firebaseKey ? `update-term--${term.firebaseKey}` : 'create-term'}" class="add-term">
+    <form id="${term.firebaseKey ? `update-term--${term.firebaseKey}` : 'create-term'}" class="add-form">
       <div class="mb-3">
         <label for="term" class="form-label">Term</label>
         <input type="text" class="form-control" id="term" aria-describedby="emailHelp" value='${term.term || ''}' required>
@@ -18,7 +18,7 @@ const addTermForm = (uid, term = {}) => {
       </select>
       <select class="btn btn-dark dropdown-toggle" type="dropdown" id="visibility" required>
         <option ${term.public === 'true' ? 'value="true" selected ><i class="fas fa-globe" aria-hidden="true"></i>Public' : 'value="false" selected><i class="fas fa-lock" aria-hidden="true"></i>Private'}</option>
-        <option ${term.public === 'false' ? 'value="false">Private' : 'value="true">Public'}</option>
+        <option ${term.public === 'true' ? 'value="false">Private' : 'value="true">Public'}</option>
       </select>
       <button type="submit" class="btn btn-success">Submit</button>
     </form>`;

--- a/components/forms/selectCategory.js
+++ b/components/forms/selectCategory.js
@@ -1,4 +1,4 @@
-import { getCategories, getUnusedCommunityCategories } from '../../api/mergedCalls';
+import { getCategories, getUnaddedCategories } from '../../api/mergedCalls';
 import renderToDom from '../../utils/renderToDom';
 import { azSortCategory } from '../../utils/sort';
 
@@ -17,7 +17,7 @@ const selectCategory = (uid, categoryId) => {
 };
 
 const selectCommunityCategory = (uid) => {
-  getUnusedCommunityCategories(uid).then((cats) => {
+  getUnaddedCategories(uid).then((cats) => {
     if (cats.length) {
       let optionsHTML = '';
       cats.sort(azSortCategory).forEach((cat) => {
@@ -30,8 +30,8 @@ const selectCommunityCategory = (uid) => {
       const auxFormHTML = `
         <form id="select-new-category" class="add-category">
           <div class="mb-3">
-            <p>Or:</p>
-            <label for="form-category" class="form-label">Add Category From Community</label>
+            <p>OR</p>
+            <label for="form-category" class="form-label">Select Category From Community&ensp;</label>
             <select class="btn btn-warning dropdown-toggle" type="dropdown" id="form-category" required>
               ${optionsHTML}
             </select>

--- a/events/domEvents.js
+++ b/events/domEvents.js
@@ -1,4 +1,4 @@
-import { deleteFullCategory, getCategories } from '../api/mergedCalls';
+import { copyToUser, deleteFullCategory, getCategories } from '../api/mergedCalls';
 import {
   getTerms, deleteTerm, getSingleTerm, updateTerm
 } from '../api/terms';
@@ -66,7 +66,10 @@ const domEvents = (uid) => {
     }
 
     if (e.target.id.includes('copy-to-user')) {
-      console.warn('Copying card to user profile');
+      const [, firebaseKey] = e.target.id.split('--');
+      copyToUser(firebaseKey, uid).then(() => {
+        getTerms(uid).then((data) => showTerms(data, uid));
+      });
     }
 
     if (e.target.id.includes('view-category')) {

--- a/events/formEvents.js
+++ b/events/formEvents.js
@@ -52,7 +52,6 @@ const formEvents = (uid) => {
     }
 
     if (e.target.id.includes('create-category')) {
-      console.warn('Creating category');
       brandNewCategory(uid).then(() => {
         document.body.id = 'categories..az..all..';
         getCategories(uid).then((data) => showCategories(data, uid));

--- a/events/navEvents.js
+++ b/events/navEvents.js
@@ -27,7 +27,7 @@ const navEvents = (uid) => {
     if (e.target.id.includes('community-tab')) {
       document.body.id = 'community..az..all..';
       document.querySelector('#search').placeholder = 'Search Community';
-      console.warn('Switching to community tab');
+      getTerms(uid).then((data) => showTerms(data, uid));
     }
   });
 

--- a/pages/termsDisplay.js
+++ b/pages/termsDisplay.js
@@ -1,4 +1,5 @@
-import { getCategories, getUnusedCommunityCategories } from '../api/mergedCalls';
+import { getAllCategories } from '../api/categories';
+import { getCategories } from '../api/mergedCalls';
 import clearDom from '../utils/clearDom';
 import { escape } from '../utils/escape';
 import renderToDom from '../utils/renderToDom';
@@ -9,11 +10,12 @@ const showTerms = async (terms, uid) => {
   let buttonsHTML = '';
   let termsHTML = '';
   const [page, sortBy, filterBy, searched] = document.body.id.split('..');
-  const categories = await getCategories(uid);
-
+  let categories = [];
   if (page === 'community') {
-    const extraCats = await getUnusedCommunityCategories(uid);
-    categories.push(...extraCats);
+    categories = await getAllCategories();
+    categories = categories.filter((cat) => terms.some((term) => cat.firebaseKey === term.category_id));
+  } else {
+    categories = await getCategories(uid);
   }
   if (searched) {
     buttonsHTML += `
@@ -97,7 +99,7 @@ const showTerms = async (terms, uid) => {
               </div>
             </div>
             <div class="term-footer">
-              ${term.uid !== uid ? `<p id="copy-to-user--${term.firebaseKey}" class="clickable">Copy To Collection</p>` : `<p id="edit-term--${term.firebaseKey}" class="clickable">Edit</p><p id="delete-term--${term.firebaseKey}" class="clickable">Delete</p>`}
+              ${term.uid !== uid ? `<p id="copy-to-user--${term.firebaseKey}" class="clickable to-collection">Copy To Collection</p>` : `<p id="edit-term--${term.firebaseKey}" class="clickable">Edit</p><p id="delete-term--${term.firebaseKey}" class="clickable">Delete</p>`}
               <p class="timestamp">Created: ${term.created}</p>
             </div>
           </div>

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -78,6 +78,7 @@ body {
 
 .clickable:hover {
   cursor: pointer;
+  text-shadow: darkgray 0 0 1px;
 }
 
 .term-footer {
@@ -99,7 +100,11 @@ body {
   text-decoration: none;
 }
 
-.add-term {
+.add-form {
   width: 90%;
   margin: 0 auto;
+}
+
+#aux-form-container {
+  margin-top: 20px;
 }


### PR DESCRIPTION
Click on "Copy to Collection" to add editable copy to user collection
- Also adds category to user profile if not yet added

Removed and replaced "getUnusedCommunityCategories"
- Add Category page now displays all nonuser categories as options
- Community page sortBy options only show categories with displayed terms

Address #11 and #12 